### PR TITLE
Add a lower bound to directory

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ dependencies:
 - aeson
 - ansi-terminal
 - bytestring
-- directory
+- directory >= 1.2.5
 - doctest
 - filepath
 - http-conduit


### PR DESCRIPTION
Due to usage of `listDirectory`, versions of the directory
package below 1.2.5 will not work.